### PR TITLE
Changed the sample Unreal server code so that the first include statement is for the matching header file

### DIFF
--- a/doc_source/integration-engines-setup-unreal.md
+++ b/doc_source/integration-engines-setup-unreal.md
@@ -98,10 +98,10 @@ The following code snippet illustrates how to initialize an Unreal Engine game s
 //processes go active on Amazon GameLift
 
 // Include game project files. "GameLiftFPS" is a sample game name, replace with file names from your own game project
+#include "GameLiftFPSGameMode.h"
 #include "GameLiftFPS.h"
 #include "Engine.h"
 #include "EngineGlobals.h"
-#include "GameLiftFPSGameMode.h"
 #include "GameLiftFPSHUD.h"
 #include "GameLiftFPSCharacter.h"
 #include "GameLiftServerSDK.h"


### PR DESCRIPTION
Description of changes: Since Unreal Engine follows IWYU practices, one of the practices is that .cpp files always include their corresponding .h file first. You can check more about IWYU [here](https://docs.unrealengine.com/en-US/Programming/BuildTools/UnrealBuildTool/IWYU/index.html). And it seems that IWYU is enabled by default so you'll actually get an error if you try compiling the original sample code as seen in my tutorial video [here](https://www.youtube.com/watch?v=Iq2LpwXogTw) at around 22:26


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
