### PR TITLE
fix variable name typo

### DIFF
--- a/doc_source/realtime-script-objects.md
+++ b/doc_source/realtime-script-objects.md
@@ -154,7 +154,7 @@ Player session ID that was referenced by the game client when it connected to th
 **Game message object**  
 Use these methods to access messages that are received by the Realtime server\. Messages received from game clients have the [RTMessage](realtime-sdk-csharp-ref-datatypes.md#realtime-sdk-csharp-ref-datatypes-rtmessage) structure\.
 
-## gameMessage\.opcode<a name="realtime-script-objects-gamemessageopcode"></a>
+## gameMessage\.opCode<a name="realtime-script-objects-gamemessageopcode"></a>
 
 Operation code contained in a message\.
 


### PR DESCRIPTION
Fix typo of the variable `gameMessage.opCode`.

Using `gameMessage.opcode` instead in realtime server scripts may cause `Handling login request from player: -1; Failed to parse login command` in the server logs. Using `gameMessage.opCode` works file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.