### PR TITLE
Update realtime-script.md

### DIFF
--- a/doc_source/realtime-script.md
+++ b/doc_source/realtime-script.md
@@ -177,7 +177,7 @@ function onPlayerDisconnect(peerId) {
                                                 "Peer " + peerId + " disconnected");
     session.getPlayers().forEach((player, playerId) => {
         if (playerId != peerId) {
-            session.sendReliableMessage(outMessage, peerId);
+            session.sendReliableMessage(outMessage, playerId);
         }
     });
     activePlayers--;


### PR DESCRIPTION
Your example sends the disconnect message to the player that just disconnected - not the players that are still in the match. I changed it so it would be as intended.

Just a side note - is it possible to change playerId variable name here to perhaps playerPeerId? playerId makes me think it's the player's id, not their peer id. Though, getPlayers() does not return playerId so, assuming the variable name playerId is actually the player's peerId is a safe assumption - one that just isn't the easiest to get to if you don't know the system well.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
